### PR TITLE
Remove the channel announcement

### DIFF
--- a/helga_jeopardy.py
+++ b/helga_jeopardy.py
@@ -329,10 +329,3 @@ def jeopardy(client, channel, nick, message, cmd, args,
     question_text = quest_func(client, channel)
 
     return question_text
-
-
-@smokesignal.on('join')
-def back_from_commercial(client, channel):
-    if (channel,) in settings.CHANNELS:
-        reset_channel(channel)
-        client.msg(channel, 'aaaand we\'re back!')


### PR DESCRIPTION
I actually removed this from the installation of helga I have - helga lives in many channels and everytime she signs on to slack, she spams the channels multiple times.