### PR TITLE
Separate links in questions into separate contextual messages

### DIFF
--- a/helga_jeopardy.py
+++ b/helga_jeopardy.py
@@ -199,6 +199,24 @@ def retrieve_question(client, channel):
 
     return question
 
+
+def clean_question(question):
+    """
+    Cleans question text.
+    :param question: The raw question text.
+    :return: A 2-tuple of the shape (<Resulting question>, <List of contextual messages to send before the question>)
+    """
+    contexts = []
+    result = question
+
+    url_matches = re.findall(URL_RE, question)
+    if any(url_matches):
+        result = re.sub(URL_RE, "", question)
+        contexts += url_matches
+
+    return result.strip(), contexts
+
+
 def scores(client, channel, nick, alltime=False):
     """
     Returns top 3 scores in past week, plus the score of requesting
@@ -328,14 +346,11 @@ def jeopardy(client, channel, nick, message, cmd, args,
 
     question_text = quest_func(client, channel)
 
-    url_matches = re.findall(URL_RE, question_text)
-    if any(url_matches):
-        question_text = re.sub(URL_RE, "", question_text)
+    result, context_messages = clean_question(question_text)
+    for m in context_messages:
+        client.msg(channel, m)
 
-        for m in url_matches:
-            client.msg(channel, m)
-
-    return question_text
+    return result
 
 
 @smokesignal.on('join')

--- a/helga_jeopardy.py
+++ b/helga_jeopardy.py
@@ -23,6 +23,8 @@ DEBUG = getattr(settings, 'HELGA_DEBUG', False)
 ANSWER_DELAY = getattr(settings, 'JEOPARDY_ANSWER_DELAY', 30)
 CHANNEL_ANNOUNCEMENT = getattr(settings, 'JEOPARDY_JOIN_MESSAGE', '')
 
+URL_RE = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+')
+
 api_endpoint = 'http://www.trivialbuzz.com/api/v1/'
 
 correct_responses = [
@@ -325,6 +327,13 @@ def jeopardy(client, channel, nick, message, cmd, args,
         return
 
     question_text = quest_func(client, channel)
+
+    url_matches = re.findall(URL_RE, question_text)
+    if any(url_matches):
+        question_text = re.sub(URL_RE, "", question_text)
+
+        for m in url_matches:
+            client.msg(channel, m)
 
     return question_text
 

--- a/test_jeopardy.py
+++ b/test_jeopardy.py
@@ -1,4 +1,4 @@
-from helga_jeopardy import jeopardy, eval_potential_answer
+from helga_jeopardy import jeopardy, eval_potential_answer, clean_question
 
 
 class TestAnswerMatching(object):
@@ -75,3 +75,20 @@ class TestAnswerMatching(object):
 
         assert correct
         assert ratio == 0.75
+
+    def test_clean_url(self):
+        question = "what is a http://test.com/?"
+        result_question, contexts = clean_question(question)
+
+        assert result_question == "what is a"
+        assert len(contexts) == 1
+        assert contexts[0] == "http://test.com/?"
+
+    def test_clean_multiple_urls(self):
+        question = "this is a thing http://abc.com/b.gif and this is also a thing https://internet.org/a.jpg"
+        result_question, contexts = clean_question(question)
+
+        assert result_question == "this is a thing  and this is also a thing"
+        assert len(contexts) == 2
+        assert contexts[0] == "http://abc.com/b.gif"
+        assert contexts[1] == "https://internet.org/a.jpg"


### PR DESCRIPTION
In reference to #1, this PR adds a method of performing post-processing on question text.

The first application of this is to split out strings matching a URL regex into their own messages that are emitted before the question. In Slack and graphical IRC clients, this should generally result in images being displayed inline, as well as giving mobile users an easier time clicking on links.